### PR TITLE
Allow nonglobal formula parameters

### DIFF
--- a/anova.boot.R
+++ b/anova.boot.R
@@ -19,7 +19,8 @@ anova.boot <- function(formula, B=1000, type="residual", seed=NULL){
   #  stop("Response must be a vector (not multivariate).")
   #}
   #else{
-    resp <- eval(lhs(formula)) ##get the response variable
+    calling.env <- parent.frame()
+    resp <- eval(lhs(formula), envir=calling.env) ##get the response variable
 
     if(is.matrix(resp)!=TRUE && is.atomic(resp)!=TRUE){
        stop("Response must be a vector or matrix.")

--- a/jackknife.R
+++ b/jackknife.R
@@ -25,7 +25,8 @@ jackknife <- function(formula){
   #  stop("Response must be a vector (not multivariate).")
   #}
   #else{
-    resp <- eval(lhs(formula)) ##get the response variable
+    calling.env <- parent.frame()
+    resp <- eval(lhs(formula), envir=calling.env) ##get the response variable
 
     if(is.matrix(resp)!=TRUE && is.atomic(resp)!=TRUE){
        stop("Response must be a vector or matrix.")

--- a/paired.boot.R
+++ b/paired.boot.R
@@ -25,7 +25,8 @@ paired.boot <- function(formula, B=1000, seed=NULL){
   #  stop("Response must be a vector (not multivariate).")
   #}
   #else{
-    resp <- eval(lhs(formula)) ##get the response variable
+    calling.env <- parent.frame()
+    resp <- eval(lhs(formula), envir=calling.env) ##get the response variable
 
     if(is.matrix(resp)!=TRUE && is.atomic(resp)!=TRUE){
        stop("Response must be a vector or matrix.")

--- a/residual.boot.R
+++ b/residual.boot.R
@@ -22,7 +22,8 @@ residual.boot <- function(formula, B=1000, seed=NULL){
   #  stop("Response must be a vector (not multivariate).")
   #}
   #else{
-    resp <- eval(lhs(formula)) ##get the response variable
+    calling.env <- parent.frame()
+    resp <- eval(lhs(formula), envir=calling.env) ##get the response variable
 
     if(is.matrix(resp)!=TRUE && is.atomic(resp)!=TRUE){
        stop("Response must be a vector or matrix.")

--- a/wild.boot.R
+++ b/wild.boot.R
@@ -53,7 +53,8 @@ wild.boot <- function(formula, B=1000, seed=NULL, distn="normal"){
   #  stop("Response must be a vector (not multivariate).")
   #}
   #else{
-    resp <- eval(lhs(formula)) ##get the response variable
+    calling.env <- parent.frame()
+    resp <- eval(lhs(formula), envir=calling.env) ##get the response variable
 
     if(is.matrix(resp)!=TRUE && is.atomic(resp)!=TRUE){
        stop("Response must be a vector or matrix.")


### PR DESCRIPTION
```
library(RCurl)
s <- getURL('https://raw.githubusercontent.com/elegacy/lm.boot/master/wild.boot.R',
           ssl.verifypeer=FALSE)

eval(parse(text=s))

test <- function() {
  y <- c(1,2,3)
  x <- c(4,5,6)
  wild.boot(y ~ x, B=1000)
}

test()
```

The above code fails with the error `Error in eval(expr, envir, enclos) : object 'y' not found`, as `y` does not exist in `eval`'s environment. Using `parent.frame()` gives you access to the calling environment, in which the formula variables should always exist.

I couldn't get my theory and simulations code to work outside of the global scope, which meant I couldn't package the changing parameters into the arguments to a function. I thought other students might find this helpful if we continue to use these bootstrap functions.